### PR TITLE
Fix links in contrib-content.md and contrib-integrations.md files

### DIFF
--- a/contrib-content.md
+++ b/contrib-content.md
@@ -2,4 +2,4 @@ This file lists approved [non-code external contributions](Readme.md#external-co
 
 GitHub Issue (repo#id) | Related Aqua [project](Readme.md#how-can-i-help) | Short description | Link to contribution
 --- | --- | --- | ---
-[Hacktoberfest#1](https://github.com/aquasecurity/Hacktoberfest/issues/1) | Hacktoberfest | This is just an example for how to fill this table | [https://github.com/aquasecurity/Hacktoberfest/blob/contrib-content.md](https://github.com/aquasecurity/Hacktoberfest/blob/contrib-content.md)
+[Hacktoberfest#1](https://github.com/aquasecurity/Hacktoberfest/issues/1) | Hacktoberfest | This is just an example for how to fill this table | [https://github.com/aquasecurity/Hacktoberfest/blob/master/contrib-content.md](https://github.com/aquasecurity/Hacktoberfest/blob/master/contrib-content.md)

--- a/contrib-content.md
+++ b/contrib-content.md
@@ -1,5 +1,5 @@
-This file lists approved [non-code external contributions](Readme.md#external-contributions.md)
+This file lists approved [non-code external contributions](Readme.md#external-contributions)
 
 GitHub Issue (repo#id) | Related Aqua [project](Readme.md#how-can-i-help) | Short description | Link to contribution
 --- | --- | --- | ---
-[Hacktoberfest#1](https://github.com/aquasecurity/Hacktoberfest/issues/1) | Hacktoberfest | This is just an example for how to fill this table | [https://github.com/aquasecurity/Hacktoberfest/contrib-content.md](https://github.com/aquasecurity/Hacktoberfest/contrib-content.md)
+[Hacktoberfest#1](https://github.com/aquasecurity/Hacktoberfest/issues/1) | Hacktoberfest | This is just an example for how to fill this table | [https://github.com/aquasecurity/Hacktoberfest/blob/contrib-content.md](https://github.com/aquasecurity/Hacktoberfest/blob/contrib-content.md)

--- a/contrib-content.md
+++ b/contrib-content.md
@@ -1,5 +1,5 @@
 This file lists approved [non-code external contributions](Readme.md#external-contributions)
 
-GitHub Issue (repo#id) | Related Aqua [project](Readme.md#how-can-i-help) | Short description | Link to contribution
+GitHub Issue (repo#id) | [Related Aqua project](Readme.md#how-can-i-help) | Short description | Link to contribution
 --- | --- | --- | ---
 [Hacktoberfest#1](https://github.com/aquasecurity/Hacktoberfest/issues/1) | Hacktoberfest | This is just an example for how to fill this table | [https://github.com/aquasecurity/Hacktoberfest/blob/master/contrib-content.md](https://github.com/aquasecurity/Hacktoberfest/blob/master/contrib-content.md)

--- a/contrib-integrations.md
+++ b/contrib-integrations.md
@@ -2,4 +2,4 @@ This file lists approved [integrations external contributions](Readme.md#externa
 
 GitHub Issue (repo#id) | Related Aqua [project](Readme.md#how-can-i-help) | Short description | Link to contribution
 --- | --- | --- | ---
-[Hacktoberfest#1](https://github.com/aquasecurity/Hacktoberfest/issues/1) | Hacktoberfest | This is just an example for how to fill this table | [https://github.com/aquasecurity/Hacktoberfest/blob/contrib-content.md](https://github.com/aquasecurity/Hacktoberfest/blob/contrib-content.md)
+[Hacktoberfest#1](https://github.com/aquasecurity/Hacktoberfest/issues/1) | Hacktoberfest | This is just an example for how to fill this table | [https://github.com/aquasecurity/Hacktoberfest/blob/master/contrib-integrations.md](https://github.com/aquasecurity/Hacktoberfest/blob/master/contrib-integrations.md)

--- a/contrib-integrations.md
+++ b/contrib-integrations.md
@@ -1,5 +1,5 @@
 This file lists approved [integrations external contributions](Readme.md#external-contributions)
 
-GitHub Issue (repo#id) | Related Aqua [project](Readme.md#how-can-i-help) | Short description | Link to contribution
+GitHub Issue (repo#id) | [Related Aqua project](Readme.md#how-can-i-help) | Short description | Link to contribution
 --- | --- | --- | ---
 [Hacktoberfest#1](https://github.com/aquasecurity/Hacktoberfest/issues/1) | Hacktoberfest | This is just an example for how to fill this table | [https://github.com/aquasecurity/Hacktoberfest/blob/master/contrib-integrations.md](https://github.com/aquasecurity/Hacktoberfest/blob/master/contrib-integrations.md)

--- a/contrib-integrations.md
+++ b/contrib-integrations.md
@@ -1,5 +1,5 @@
-This file lists approved [integrations external contributions](Readme.md#external-contributions.md)
+This file lists approved [integrations external contributions](Readme.md#external-contributions)
 
 GitHub Issue (repo#id) | Related Aqua [project](Readme.md#how-can-i-help) | Short description | Link to contribution
 --- | --- | --- | ---
-[Hacktoberfest#1](https://github.com/aquasecurity/Hacktoberfest/issues/1) | Hacktoberfest | This is just an example for how to fill this table | [https://github.com/aquasecurity/Hacktoberfest/contrib-content.md](https://github.com/aquasecurity/Hacktoberfest/contrib-content.md)
+[Hacktoberfest#1](https://github.com/aquasecurity/Hacktoberfest/issues/1) | Hacktoberfest | This is just an example for how to fill this table | [https://github.com/aquasecurity/Hacktoberfest/blob/contrib-content.md](https://github.com/aquasecurity/Hacktoberfest/blob/contrib-content.md)


### PR DESCRIPTION
This addresses the problems identified in issue #6 with the contrib-content.md and contrib-integrations.md files.

Changes:
- Fixes the anchor links to https://github.com/aquasecurity/Hacktoberfest#external-contributions
- Makes the link in the example for filling out a table point to the markdown files instead of links that give 404 not found errors
- The entire table header text "Related Aqua project" is now a link