### PR TITLE
add external contribution packaging trivy in nixpkgs

### DIFF
--- a/contrib-integrations.md
+++ b/contrib-integrations.md
@@ -3,3 +3,4 @@ This file lists approved [integrations external contributions](Readme.md#externa
 GitHub Issue (repo#id) | [Related Aqua project](Readme.md#how-can-i-help) | Short description | Link to contribution
 --- | --- | --- | ---
 [Hacktoberfest#1](https://github.com/aquasecurity/Hacktoberfest/issues/1) | Hacktoberfest | This is just an example for how to fill this table | [https://github.com/aquasecurity/Hacktoberfest/blob/master/contrib-integrations.md](https://github.com/aquasecurity/Hacktoberfest/blob/master/contrib-integrations.md)
+[trivy#685](https://github.com/aquasecurity/trivy/issues/685) | trivy | Packaged trivy for nix and nixOS | <https://github.com/NixOS/nixpkgs/pull/99407>


### PR DESCRIPTION
Issue: https://github.com/aquasecurity/trivy/issues/685
Contribution: https://github.com/NixOS/nixpkgs/pull/99407

LMK if I've followed this process right, I wasn't quite sure if I should have the issue in the trivy repo or here